### PR TITLE
Update 4.2-custom-modules.md

### DIFF
--- a/4-back-end-development/4.2-custom-modules.md
+++ b/4-back-end-development/4.2-custom-modules.md
@@ -42,7 +42,7 @@ The following keys are available for modules:
 
 - **name (required)** - The human-readable name. This will appear on the "Extend" page where the module is activated.
 - **type (required)** - Indicates the type of extension, i.e., "module", "theme", or "profile". For modules this should always be set to "module".
-- **description (required)** - The description, displayed on the "Extend" page.
+- **description (optional)** - The description, displayed on the "Extend" page.
 - **package (optional)** - Specifies a "package" that allows you to group modules together.
 - **core (required)** - Specifies the version of Drupal core that the theme is compatible with.
 - **php (optional)** - The minimum version of PHP required. Defaults to value of `DRUPAL_MINIMUM_PHP` constant.


### PR DESCRIPTION
According to Drupal.org [https://www.drupal.org/docs/8/creating-custom-modules/let-drupal-8-know-about-your-module-with-an-infoyml-file] description key is optional.