### PR TITLE
Update 4.4-essential-apis-menu.md

### DIFF
--- a/4-back-end-development/4.4-essential-apis-menu.md
+++ b/4-back-end-development/4.4-essential-apis-menu.md
@@ -112,7 +112,7 @@ protected static function buildPreRenderableBlock($entity, ModuleHandlerInterfac
 
 In the above example `'block'` refers to the contextual link group called `'block'`.
 
-Additionally, `hook_contextual_links_view_alter()` can be used to dynamically generate new and alter existing contextual links.
+Additionally, `hook_contextual_links_view_alter()` or `hook_contextual_links_alter()` can be used to dynamically generate new and alter existing contextual links.
 
 ## Additional Resources
 - [Menu API](https://www.drupal.org/docs/8/api/menu-api)


### PR DESCRIPTION
There is another hook can be used to alter the render array of a contextual link `hook_contextual_links_alter()`.